### PR TITLE
Remove exception that is thrown on servers

### DIFF
--- a/forge/src/main/java/traben/entity_model_features/forge/EMFForge.java
+++ b/forge/src/main/java/traben/entity_model_features/forge/EMFForge.java
@@ -34,9 +34,6 @@ public class EMFForge {
             }
 
             EMF.init();
-        } else {
-
-            throw new UnsupportedOperationException("Attempting to load a clientside only mod [EMF] on the server, refusing");
         }
     }
 }

--- a/neoforge/src/main/java/traben/entity_model_features/neoforge/EMFNeoForge.java
+++ b/neoforge/src/main/java/traben/entity_model_features/neoforge/EMFNeoForge.java
@@ -44,9 +44,6 @@ public class EMFNeoForge {
             }
 
             EMF.init();
-        } else {
-
-            throw new UnsupportedOperationException("Attempting to load a clientside only mod [EMF] on the server, refusing");
         }
     }
 }


### PR DESCRIPTION
This PR removes the exception that is thrown when EMF is loaded on a server.
Without this, the server launches without any errors, even if EMF is installed.

According to [the forge documentation](https://docs.minecraftforge.net/en/1.21.x/concepts/sides/#writing-one-sided-mods), one-sided mods should still work on the incorrect side.

> Basically, if your mod is loaded on the wrong side, it should simply do nothing, listen to no events, and so on.
