### PR TITLE
Fix player model shaking in GUI with animation packs

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,7 @@
 
 [3.1]
 - ESF will need to update to be compatible with this version
+- fixed entity animations jittering in guis with certain animation packs
 - fixed ArrayIndexOutOfBoundsException crash on 26.1+
 - added a setting to control which models EMF will attempt to load for, e.g. Known (most vanilla / OptiFine) or unknown (mostly modded)
 - temporarily incompatible with ESF

--- a/src/main/java/traben/entity_model_features/mixin/mixins/MixinEntity.java
+++ b/src/main/java/traben/entity_model_features/mixin/mixins/MixinEntity.java
@@ -5,6 +5,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -23,6 +24,8 @@ public abstract class MixinEntity implements EMFEntity {
 
     @Unique
     private final Map<String, Float> emf$variableMap = new HashMap<>();
+    @Unique
+    private @Nullable Map<String, Float> emf$variableMapGuiCopy = null;
 
 
     @Shadow
@@ -269,6 +272,11 @@ public abstract class MixinEntity implements EMFEntity {
 
     @Override
     public Map<String, Float> emf$getVariableMap() {
+        if (EMFAnimationEntityContext.isInGui()) {
+            // Copy the initial variable state but allow the gui to now change these separately
+            if (emf$variableMapGuiCopy == null) emf$variableMapGuiCopy = new HashMap<>(emf$variableMap);
+            return emf$variableMapGuiCopy;
+        }
         return emf$variableMap;
     }
 }

--- a/src/main/java/traben/entity_model_features/models/animation/EMFAnimationEntityContext.java
+++ b/src/main/java/traben/entity_model_features/models/animation/EMFAnimationEntityContext.java
@@ -528,7 +528,7 @@ public final class EMFAnimationEntityContext {
 
         //#if MC >= 12102
         if (getEntityRenderState() instanceof LivingEntityRenderState livingEntityRenderState) {
-            if (setIsInGui) {
+            if (isInGui()) {
                 // entity isn't actually walking in the gui, zero these out so animations don't jitter
                 limbAngle = 0;
                 limbDistance = 0;
@@ -541,7 +541,7 @@ public final class EMFAnimationEntityContext {
                 headYaw = (Mth.wrapDegrees(headYaw));
             }
             headPitch = livingEntityRenderState.xRot;
-        }else{ //block entity
+        } else { //block entity
             limbAngle = Float.NaN;
             limbDistance = Float.NaN;
             headYaw = Float.NaN;

--- a/src/main/java/traben/entity_model_features/models/animation/EMFAnimationEntityContext.java
+++ b/src/main/java/traben/entity_model_features/models/animation/EMFAnimationEntityContext.java
@@ -530,8 +530,14 @@ public final class EMFAnimationEntityContext {
 
         //#if MC >= 12102
         if (getEntityRenderState() instanceof LivingEntityRenderState livingEntityRenderState) {
-            limbAngle = livingEntityRenderState.walkAnimationPos;
-            limbDistance = livingEntityRenderState.walkAnimationSpeed;
+            if (setIsInGui) {
+                // entity isn't actually walking in the gui, zero these out so animations don't jitter
+                limbAngle = 0;
+                limbDistance = 0;
+            } else {
+                limbAngle = livingEntityRenderState.walkAnimationPos;
+                limbDistance = livingEntityRenderState.walkAnimationSpeed;
+            }
             headYaw = livingEntityRenderState.yRot;
             if (headYaw >= 180 || headYaw < -180) {
                 headYaw = (Mth.wrapDegrees(headYaw));
@@ -767,6 +773,14 @@ public final class EMFAnimationEntityContext {
 
     public static float getEntityRY() {
         if (emfState == null) return 0;
+        // yBodyRotO/yBodyRot oscillate between ticks while inventory is open, skip the lerp in gui
+        if (isInGui()) {
+            return (emfEntity() instanceof LivingEntity alive) ?
+                    (float) Math.toRadians(alive.yBodyRot) :
+                    emfEntity() instanceof Entity entity ?
+                            (float) Math.toRadians(entity.getYRot())
+                            : 0;
+        }
         return (emfEntity() instanceof LivingEntity alive) ?
                 (float) Math.toRadians(Mth.rotLerp(getTickDelta(), alive.yBodyRotO, alive.yBodyRot)) :
                 emfEntity() instanceof Entity entity ?
@@ -1139,6 +1153,7 @@ public final class EMFAnimationEntityContext {
     }
 
     public static float getSwingProgress() {
+        if (isInGui()) return 0;
         return emfEntity() instanceof LivingEntity alive ? alive.getAttackAnim(getTickDelta()) : 0;
     }
 
@@ -1349,7 +1364,7 @@ public final class EMFAnimationEntityContext {
 
 
     public static float getMoveForward() {
-        if (emfState == null) return 0;
+        if (emfState == null || isInGui()) return 0;
         double lookDir = Math.toRadians(90 - emfState.yaw());
         //float speed = entity.horizontalSpeed;
         Vec3 velocity = emfState.emfVelocity();
@@ -1367,7 +1382,7 @@ public final class EMFAnimationEntityContext {
     }
 
     public static float getMoveStrafe() {
-        if (emfState == null) return 0;
+        if (emfState == null || isInGui()) return 0;
         double lookDir = Math.toRadians(90 - emfState.yaw());
         //float speed = entity.horizontalSpeed;
         Vec3 velocity = emfState.emfVelocity();


### PR DESCRIPTION
Fixes #498

The entity still ticks while the inventory is open so animation inputs like body rotation and limb swing keep changing between frames. Fresh Animations picks up on those jittering values and you get a shaking player model.

Changes in EMFAnimationEntityContext:
- zero out limbAngle/limbDistance in newEntity() when in gui, the player isn't walking
- skip rotLerp for body rotation in getEntityRY() when in gui, just use the current value instead of lerping between old/new
- return 0 for getSwingProgress(), getMoveForward(), getMoveStrafe() when in gui

head yaw/pitch from the render state are left alone since those are the mouse tracking values set by the gui